### PR TITLE
fix: Pass collection node instead of ID to createVariable

### DIFF
--- a/src/import/creators/primitives.ts
+++ b/src/import/creators/primitives.ts
@@ -97,7 +97,7 @@ export async function createPrimitivesCollection(
 				// Create new variable
 				variable = figma.variables.createVariable(
 					path,
-					collection.id,
+					collection,
 					type
 				);
 				result.variablesCreated++;

--- a/src/import/creators/wp-settings-colors.ts
+++ b/src/import/creators/wp-settings-colors.ts
@@ -87,7 +87,7 @@ export async function createColorPaletteCollection(
 				// Create new variable
 				variable = figma.variables.createVariable(
 					variableName,
-					collection.id,
+					collection,
 					'COLOR'
 				);
 				result.variablesCreated++;

--- a/src/import/creators/wp-settings-spacing.ts
+++ b/src/import/creators/wp-settings-spacing.ts
@@ -136,7 +136,7 @@ export async function createSpacingCollection(
 			} else {
 				variable = figma.variables.createVariable(
 					variableName,
-					collection.id,
+					collection,
 					'FLOAT'
 				);
 				result.variablesCreated++;

--- a/src/import/creators/wp-settings-typography.ts
+++ b/src/import/creators/wp-settings-typography.ts
@@ -121,7 +121,7 @@ export async function createTypographyCollection(
 				} else {
 					variable = figma.variables.createVariable(
 						variableName,
-						collection.id,
+						collection,
 						'FLOAT'
 					);
 					result.variablesCreated++;


### PR DESCRIPTION
## Summary
Fixes Figma variable creation errors by passing the collection node object instead of just the collection ID string to `createVariable()`. The Figma API now requires the full node object when running in incremental mode.

## What Changed
Updated all four variable creator modules to pass `collection` instead of `collection.id` to `figma.variables.createVariable()`. This resolves the "Cannot call createVariable with a collection id in incremental mode" errors that were preventing theme.json imports.

## Testing
The build passes with no TypeScript errors. Import should now successfully create variables for font weights, line heights, colors, font sizes, and spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)