### PR TITLE
feat: Add schema-based variable creation feature

### DIFF
--- a/create-from-schema.html
+++ b/create-from-schema.html
@@ -1,0 +1,912 @@
+<style>
+	:root {
+	  --spacing: 0.8rem;
+	}
+
+	* {
+	  box-sizing: border-box;
+	  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+		Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
+		sans-serif;
+	}
+
+	body {
+	  background-color: var(--figma-color-bg);
+	  color: var(--figma-color-text);
+	  margin: 0;
+	  padding: var(--spacing);
+	  min-height: 400px;
+	  min-width: 400px;
+	  position: relative;
+	  overflow: hidden;
+	}
+
+	html,
+	body {
+	  height: 100%;
+	}
+
+	main {
+	  display: flex;
+	  flex-direction: column;
+	  gap: var(--spacing);
+	  height: 100%;
+	  overflow: hidden;
+	}
+
+	button {
+	  appearance: none;
+	  border-radius: 4px;
+	  padding: var(--spacing);
+	  cursor: pointer;
+	}
+
+	button {
+	  background-color: var(--figma-color-bg-brand);
+	  border: none;
+	  color: var(--figma-color-text-onbrand);
+	  font-weight: bold;
+	}
+
+	.info-text {
+	  font-size: 0.9rem;
+	  margin-bottom: var(--spacing);
+	  color: var(--figma-color-text-secondary);
+	  flex-shrink: 0;
+	}
+
+	/* Step navigation styles */
+	.step-navigation {
+	  display: flex;
+	  align-items: center;
+	  gap: calc(var(--spacing) / 2);
+	  margin-bottom: var(--spacing);
+	  padding: calc(var(--spacing) / 2);
+	  background-color: var(--figma-color-bg-secondary);
+	  border-radius: 4px;
+	  flex-shrink: 0;
+	}
+
+	.step-indicator {
+	  display: flex;
+	  align-items: center;
+	  gap: calc(var(--spacing) / 4);
+	  padding: calc(var(--spacing) / 4) calc(var(--spacing) / 2);
+	  border-radius: 4px;
+	  font-size: 0.8rem;
+	  font-weight: 500;
+	  cursor: pointer;
+	  transition: all 0.2s;
+	}
+
+	.step-indicator span:first-child {
+	  display: flex;
+	  align-items: center;
+	  justify-content: center;
+	  width: 20px;
+	  height: 20px;
+	  border-radius: 50%;
+	  font-size: 0.7rem;
+	  font-weight: bold;
+	}
+
+	.step-indicator.active {
+	  background-color: var(--figma-color-bg-brand);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	.step-indicator.active span:first-child {
+	  background-color: var(--figma-color-text-onbrand);
+	  color: var(--figma-color-bg-brand);
+	}
+
+	.step-indicator.completed {
+	  background-color: var(--figma-color-bg-success);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	.step-indicator:not(.active):not(.completed) {
+	  background-color: var(--figma-color-bg);
+	  color: var(--figma-color-text-secondary);
+	}
+
+	.step-indicator:not(.active):not(.completed) span:first-child {
+	  background-color: var(--figma-color-bg-secondary);
+	}
+
+	.step-content {
+	  display: none;
+	  flex: 1;
+	  overflow: hidden;
+	  flex-direction: column;
+	}
+
+	.step-content.active {
+	  display: flex;
+	}
+
+	.step-actions {
+	  display: flex;
+	  justify-content: space-between;
+	  align-items: center;
+	  margin-top: var(--spacing);
+	  padding-top: var(--spacing);
+	  border-top: 1px solid var(--figma-color-border);
+	  flex-shrink: 0;
+	}
+
+	.step-button {
+	  padding: calc(var(--spacing) / 2) var(--spacing);
+	  border-radius: 4px;
+	  font-weight: 500;
+	  cursor: pointer;
+	  border: none;
+	}
+
+	.step-button.primary {
+	  background-color: var(--figma-color-bg-brand);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	.step-button.secondary {
+	  background-color: var(--figma-color-bg-secondary);
+	  color: var(--figma-color-text);
+	}
+
+	.step-button:disabled {
+	  background-color: var(--figma-color-bg-disabled);
+	  color: var(--figma-color-text-disabled);
+	  cursor: not-allowed;
+	}
+
+	/* Section cards */
+	.section-list {
+	  flex: 1;
+	  overflow-y: auto;
+	  min-height: 0;
+	}
+
+	.section-card {
+	  border: 2px solid var(--figma-color-border);
+	  border-radius: 8px;
+	  margin-bottom: var(--spacing);
+	  overflow: hidden;
+	  transition: border-color 0.2s;
+	}
+
+	.section-card.selected {
+	  border-color: var(--figma-color-bg-brand);
+	}
+
+	.section-card-header {
+	  display: flex;
+	  align-items: center;
+	  gap: var(--spacing);
+	  padding: var(--spacing);
+	  background-color: var(--figma-color-bg-secondary);
+	  cursor: pointer;
+	}
+
+	.section-card-header input[type="checkbox"] {
+	  width: 18px;
+	  height: 18px;
+	  cursor: pointer;
+	}
+
+	.section-card-info {
+	  flex: 1;
+	}
+
+	.section-card-title {
+	  font-weight: 600;
+	  font-size: 0.95rem;
+	}
+
+	.section-card-description {
+	  font-size: 0.8rem;
+	  color: var(--figma-color-text-secondary);
+	  margin-top: 2px;
+	}
+
+	.section-card-badges {
+	  display: flex;
+	  gap: calc(var(--spacing) / 2);
+	}
+
+	.badge {
+	  padding: 2px 8px;
+	  border-radius: 10px;
+	  font-size: 0.7rem;
+	  font-weight: bold;
+	}
+
+	.badge.count {
+	  background-color: var(--figma-color-bg-brand);
+	  color: var(--figma-color-text-onbrand);
+	}
+
+	.badge.exists {
+	  background-color: #f0ad4e;
+	  color: #000;
+	}
+
+	.badge.new {
+	  background-color: #5cb85c;
+	  color: #fff;
+	}
+
+	.section-card-preview {
+	  padding: calc(var(--spacing) / 2) var(--spacing);
+	  background-color: var(--figma-color-bg);
+	  border-top: 1px solid var(--figma-color-border);
+	  max-height: 120px;
+	  overflow-y: auto;
+	}
+
+	.variable-preview-list {
+	  display: flex;
+	  flex-wrap: wrap;
+	  gap: calc(var(--spacing) / 4);
+	}
+
+	.variable-tag {
+	  background-color: var(--figma-color-bg-secondary);
+	  padding: 2px 8px;
+	  border-radius: 4px;
+	  font-size: 0.75rem;
+	  font-family: monospace;
+	  display: flex;
+	  align-items: center;
+	  gap: 4px;
+	}
+
+	.variable-tag.exists {
+	  opacity: 0.5;
+	  text-decoration: line-through;
+	}
+
+	.color-swatch {
+	  width: 12px;
+	  height: 12px;
+	  border-radius: 2px;
+	  border: 1px solid var(--figma-color-border);
+	}
+
+	/* Options section */
+	.options-section {
+	  background-color: var(--figma-color-bg-secondary);
+	  padding: var(--spacing);
+	  border-radius: 4px;
+	  flex-shrink: 0;
+	}
+
+	.option-row {
+	  display: flex;
+	  align-items: center;
+	  gap: calc(var(--spacing) / 2);
+	  margin-bottom: calc(var(--spacing) / 2);
+	}
+
+	.option-row:last-child {
+	  margin-bottom: 0;
+	}
+
+	.option-row label {
+	  font-size: 0.9rem;
+	  cursor: pointer;
+	}
+
+	.option-row select {
+	  padding: calc(var(--spacing) / 4) calc(var(--spacing) / 2);
+	  border-radius: 4px;
+	  border: 1px solid var(--figma-color-border);
+	  background-color: var(--figma-color-bg);
+	  color: var(--figma-color-text);
+	}
+
+	/* Warnings */
+	.warnings-section {
+	  background-color: #fff3cd;
+	  border: 1px solid #ffc107;
+	  border-radius: 4px;
+	  padding: calc(var(--spacing) / 2);
+	  margin-bottom: var(--spacing);
+	  flex-shrink: 0;
+	}
+
+	.warnings-title {
+	  font-weight: 600;
+	  color: #856404;
+	  font-size: 0.85rem;
+	  margin-bottom: calc(var(--spacing) / 4);
+	}
+
+	.warnings-list {
+	  list-style: none;
+	  padding: 0;
+	  margin: 0;
+	  max-height: 80px;
+	  overflow-y: auto;
+	}
+
+	.warnings-list li {
+	  font-size: 0.8rem;
+	  color: #856404;
+	  padding: 2px 0;
+	}
+
+	/* Info banner */
+	.info-banner {
+	  background-color: var(--figma-color-bg-secondary);
+	  border: 1px solid var(--figma-color-border);
+	  border-radius: 4px;
+	  padding: calc(var(--spacing) / 2) var(--spacing);
+	  margin-bottom: var(--spacing);
+	  font-size: 0.85rem;
+	  display: flex;
+	  align-items: center;
+	  gap: calc(var(--spacing) / 2);
+	}
+
+	.info-banner.success {
+	  background-color: rgba(92, 184, 92, 0.1);
+	  border-color: rgba(92, 184, 92, 0.3);
+	}
+
+	/* Results section */
+	.results-section {
+	  flex: 1;
+	  overflow-y: auto;
+	  min-height: 0;
+	}
+
+	.result-summary {
+	  background-color: var(--figma-color-bg-secondary);
+	  padding: var(--spacing);
+	  border-radius: 4px;
+	  margin-bottom: var(--spacing);
+	}
+
+	.result-summary.success {
+	  background-color: rgba(0, 180, 0, 0.1);
+	  border: 1px solid rgba(0, 180, 0, 0.3);
+	}
+
+	.result-summary.error {
+	  background-color: rgba(255, 0, 0, 0.1);
+	  border: 1px solid rgba(255, 0, 0, 0.3);
+	}
+
+	.result-stat {
+	  display: flex;
+	  justify-content: space-between;
+	  font-size: 0.9rem;
+	  padding: calc(var(--spacing) / 4) 0;
+	}
+
+	.result-stat-value {
+	  font-weight: 600;
+	}
+
+	.result-collections {
+	  margin-top: var(--spacing);
+	}
+
+	.result-collection {
+	  display: flex;
+	  justify-content: space-between;
+	  align-items: center;
+	  padding: calc(var(--spacing) / 2);
+	  background-color: var(--figma-color-bg);
+	  border: 1px solid var(--figma-color-border);
+	  border-radius: 4px;
+	  margin-bottom: calc(var(--spacing) / 2);
+	  font-size: 0.9rem;
+	}
+
+	/* Loading state */
+	.loading {
+	  display: flex;
+	  align-items: center;
+	  justify-content: center;
+	  gap: var(--spacing);
+	  padding: var(--spacing);
+	  color: var(--figma-color-text-secondary);
+	  font-style: italic;
+	}
+
+	@keyframes spin {
+	  to { transform: rotate(360deg); }
+	}
+
+	.spinner {
+	  width: 16px;
+	  height: 16px;
+	  border: 2px solid var(--figma-color-border);
+	  border-top-color: var(--figma-color-bg-brand);
+	  border-radius: 50%;
+	  animation: spin 1s linear infinite;
+	}
+
+	/* Resize handle */
+	.resize-handle {
+	  position: absolute;
+	  bottom: 0;
+	  right: 0;
+	  width: 20px;
+	  height: 20px;
+	  cursor: nwse-resize;
+	  z-index: 100;
+	  opacity: 0.7;
+	}
+
+	.resize-handle:before,
+	.resize-handle:after {
+	  content: "";
+	  position: absolute;
+	  background-color: var(--figma-color-border);
+	}
+
+	.resize-handle:before {
+	  width: 2px;
+	  height: 12px;
+	  bottom: 3px;
+	  right: 8px;
+	  transform: rotate(45deg);
+	}
+
+	.resize-handle:after {
+	  width: 12px;
+	  height: 2px;
+	  bottom: 8px;
+	  right: 3px;
+	  transform: rotate(45deg);
+	}
+
+	.resize-overlay {
+	  position: fixed;
+	  top: 0;
+	  left: 0;
+	  width: 100%;
+	  height: 100%;
+	  z-index: 99;
+	  display: none;
+	  cursor: nwse-resize;
+	}
+</style>
+
+<main>
+	<!-- Step Navigation -->
+	<div class="step-navigation">
+		<div class="step-indicator active" data-step="1">
+			<span>1</span>
+			<span>Select</span>
+		</div>
+		<div class="step-indicator" data-step="2">
+			<span>2</span>
+			<span>Configure</span>
+		</div>
+		<div class="step-indicator" data-step="3">
+			<span>3</span>
+			<span>Create</span>
+		</div>
+	</div>
+
+	<!-- Step 1: Select Sections -->
+	<div class="step-content active" id="step-1">
+		<div class="info-text">
+			Select which variable collections to create based on the WordPress theme.json schema.
+			Existing variables will be preserved (skipped by default).
+		</div>
+
+		<div class="section-list" id="section-list">
+			<div class="loading" id="sections-loading">
+				<div class="spinner"></div>
+				<span>Loading sections...</span>
+			</div>
+		</div>
+
+		<div class="step-actions">
+			<div></div>
+			<button type="button" class="step-button primary" id="next-to-step-2" disabled>Next: Configure</button>
+		</div>
+	</div>
+
+	<!-- Step 2: Configure Options -->
+	<div class="step-content" id="step-2">
+		<div class="info-text">
+			Configure how variables should be created.
+		</div>
+
+		<div class="options-section">
+			<div class="option-row">
+				<label for="conflict-strategy">When variable exists:</label>
+				<select id="conflict-strategy">
+					<option value="skip" selected>Skip (preserve existing)</option>
+					<option value="overwrite">Overwrite (replace with placeholder)</option>
+					<option value="rename">Rename (create new collection)</option>
+				</select>
+			</div>
+		</div>
+
+		<div class="warnings-section" id="warnings-section" style="display: none;">
+			<div class="warnings-title">Existing Collections Detected</div>
+			<ul class="warnings-list" id="warnings-list"></ul>
+		</div>
+
+		<div class="info-banner" id="schema-source-banner">
+			Using default placeholder values based on WordPress conventions.
+		</div>
+
+		<div class="section-list" id="preview-section">
+			<!-- Preview will be populated here -->
+		</div>
+
+		<div class="step-actions">
+			<button type="button" class="step-button secondary" id="back-to-step-1">Back</button>
+			<button type="button" class="step-button primary" id="next-to-step-3">Create Variables</button>
+		</div>
+	</div>
+
+	<!-- Step 3: Create -->
+	<div class="step-content" id="step-3">
+		<div class="info-text" id="step-3-info">
+			Creating variables...
+		</div>
+
+		<div class="results-section" id="results-section">
+			<div class="loading" id="create-loading">
+				<div class="spinner"></div>
+				<span>Creating collections and variables...</span>
+			</div>
+
+			<div class="result-summary" id="result-summary" style="display: none;">
+				<div class="result-stat">
+					<span>Collections created:</span>
+					<span class="result-stat-value" id="collections-created">0</span>
+				</div>
+				<div class="result-stat">
+					<span>Variables created:</span>
+					<span class="result-stat-value" id="variables-created">0</span>
+				</div>
+				<div class="result-stat">
+					<span>Variables skipped:</span>
+					<span class="result-stat-value" id="variables-skipped">0</span>
+				</div>
+
+				<div class="result-collections" id="result-collections"></div>
+			</div>
+
+			<div class="warnings-section" id="result-warnings-section" style="display: none;">
+				<div class="warnings-title">Warnings</div>
+				<ul class="warnings-list" id="result-warnings-list"></ul>
+			</div>
+		</div>
+
+		<div class="step-actions">
+			<button type="button" class="step-button secondary" id="back-to-step-2" style="display: none;">Back</button>
+			<button type="button" class="step-button primary" id="create-another" style="display: none;">Create More</button>
+		</div>
+	</div>
+</main>
+
+<div class="resize-handle" id="resize-handle"></div>
+<div class="resize-overlay" id="resize-overlay"></div>
+
+<script>
+	let currentStep = 1;
+	let previewData = null;
+	let selectedSections = {
+		colors: true,
+		typography: true,
+		spacing: true
+	};
+
+	// Resize functionality
+	const resizeHandle = document.getElementById('resize-handle');
+	const resizeOverlay = document.getElementById('resize-overlay');
+	let isResizing = false;
+	let initialWidth, initialHeight, initialX, initialY;
+
+	resizeHandle.addEventListener('mousedown', initResize);
+
+	function initResize(e) {
+		e.preventDefault();
+		initialWidth = window.innerWidth;
+		initialHeight = window.innerHeight;
+		initialX = e.clientX;
+		initialY = e.clientY;
+		resizeOverlay.style.display = 'block';
+		isResizing = true;
+		window.addEventListener('mousemove', resizeWindow);
+		window.addEventListener('mouseup', stopResize);
+	}
+
+	function resizeWindow(e) {
+		if (!isResizing) return;
+		const newWidth = initialWidth + (e.clientX - initialX);
+		const newHeight = initialHeight + (e.clientY - initialY);
+		const width = Math.max(300, newWidth);
+		const height = Math.max(300, newHeight);
+		parent.postMessage({
+			pluginMessage: { type: "RESIZE", width, height }
+		}, "*");
+	}
+
+	function stopResize() {
+		isResizing = false;
+		resizeOverlay.style.display = 'none';
+		window.removeEventListener('mousemove', resizeWindow);
+		window.removeEventListener('mouseup', stopResize);
+	}
+
+	// Load initial preview
+	function loadPreview() {
+		parent.postMessage({
+			pluginMessage: {
+				type: "PREVIEW_SCHEMA_CREATE",
+				options: { sections: selectedSections }
+			}
+		}, "*");
+	}
+
+	// Render section cards
+	function renderSections(sections) {
+		const container = document.getElementById('section-list');
+		container.innerHTML = '';
+
+		sections.forEach(section => {
+			const card = document.createElement('div');
+			card.className = `section-card ${selectedSections[section.id] ? 'selected' : ''}`;
+			card.dataset.sectionId = section.id;
+
+			const newCount = section.variableCount - section.existingCount;
+
+			card.innerHTML = `
+				<div class="section-card-header">
+					<input type="checkbox" ${selectedSections[section.id] ? 'checked' : ''} data-section="${section.id}" />
+					<div class="section-card-info">
+						<div class="section-card-title">${section.displayName}</div>
+						<div class="section-card-description">${section.collectionName}</div>
+					</div>
+					<div class="section-card-badges">
+						${section.collectionExists ? '<span class="badge exists">Exists</span>' : ''}
+						<span class="badge ${newCount > 0 ? 'new' : 'count'}">${newCount > 0 ? newCount + ' new' : section.variableCount + ' vars'}</span>
+					</div>
+				</div>
+				<div class="section-card-preview">
+					<div class="variable-preview-list">
+						${section.variables.map(v => `
+							<span class="variable-tag ${v.exists ? 'exists' : ''}">
+								${section.id === 'colors' ? `<span class="color-swatch" style="background-color: ${v.value}"></span>` : ''}
+								${v.name}${v.exists ? ' (exists)' : ''}
+							</span>
+						`).join('')}
+					</div>
+				</div>
+			`;
+
+			// Handle checkbox change
+			const checkbox = card.querySelector('input[type="checkbox"]');
+			checkbox.addEventListener('change', (e) => {
+				selectedSections[section.id] = e.target.checked;
+				card.classList.toggle('selected', e.target.checked);
+				updateNextButton();
+			});
+
+			// Handle header click (toggle checkbox)
+			const header = card.querySelector('.section-card-header');
+			header.addEventListener('click', (e) => {
+				if (e.target.type !== 'checkbox') {
+					checkbox.checked = !checkbox.checked;
+					checkbox.dispatchEvent(new Event('change'));
+				}
+			});
+
+			container.appendChild(card);
+		});
+
+		updateNextButton();
+	}
+
+	function updateNextButton() {
+		const anySelected = Object.values(selectedSections).some(v => v);
+		document.getElementById('next-to-step-2').disabled = !anySelected;
+	}
+
+	// Render preview for step 2
+	function renderPreview(sections) {
+		const container = document.getElementById('preview-section');
+		container.innerHTML = '';
+
+		const selectedSectionData = sections.filter(s => selectedSections[s.id]);
+
+		selectedSectionData.forEach(section => {
+			const card = document.createElement('div');
+			card.className = 'section-card selected';
+
+			const newCount = section.variableCount - section.existingCount;
+
+			card.innerHTML = `
+				<div class="section-card-header" style="cursor: default;">
+					<div class="section-card-info">
+						<div class="section-card-title">${section.displayName}</div>
+						<div class="section-card-description">${section.collectionName}</div>
+					</div>
+					<div class="section-card-badges">
+						${section.existingCount > 0 ? `<span class="badge exists">${section.existingCount} exist</span>` : ''}
+						<span class="badge new">${newCount} to create</span>
+					</div>
+				</div>
+				<div class="section-card-preview">
+					<div class="variable-preview-list">
+						${section.variables.map(v => `
+							<span class="variable-tag ${v.exists ? 'exists' : ''}">
+								${section.id === 'colors' ? `<span class="color-swatch" style="background-color: ${v.value}"></span>` : ''}
+								${v.name}${v.exists ? ' (skip)' : ''}
+							</span>
+						`).join('')}
+					</div>
+				</div>
+			`;
+
+			container.appendChild(card);
+		});
+	}
+
+	// Step navigation
+	function showStep(step) {
+		document.querySelectorAll('.step-content').forEach(c => c.classList.remove('active'));
+		document.querySelectorAll('.step-indicator').forEach(i => {
+			i.classList.remove('active', 'completed');
+			const indicatorStep = parseInt(i.dataset.step);
+			if (indicatorStep === step) {
+				i.classList.add('active');
+			} else if (indicatorStep < step) {
+				i.classList.add('completed');
+			}
+		});
+		document.getElementById(`step-${step}`).classList.add('active');
+		currentStep = step;
+
+		if (step === 2 && previewData) {
+			renderPreview(previewData.sections);
+
+			// Show warnings for existing collections
+			const existingCollections = previewData.existingCollections;
+			if (existingCollections.length > 0) {
+				document.getElementById('warnings-section').style.display = 'block';
+				document.getElementById('warnings-list').innerHTML = existingCollections.map(c =>
+					`<li>${c.name}: ${c.variableCount} existing variable(s)</li>`
+				).join('');
+			} else {
+				document.getElementById('warnings-section').style.display = 'none';
+			}
+
+			// Update schema source banner
+			const banner = document.getElementById('schema-source-banner');
+			if (previewData.schemaSource === 'fetched') {
+				banner.textContent = 'Using WordPress theme.json schema definitions.';
+				banner.classList.add('success');
+			} else {
+				banner.textContent = 'Using default placeholder values based on WordPress conventions.';
+				banner.classList.remove('success');
+			}
+		} else if (step === 3) {
+			runCreate();
+		}
+	}
+
+	document.querySelectorAll('.step-indicator').forEach(indicator => {
+		indicator.addEventListener('click', () => {
+			const step = parseInt(indicator.dataset.step);
+			if (step <= currentStep) {
+				showStep(step);
+			}
+		});
+	});
+
+	document.getElementById('next-to-step-2').addEventListener('click', () => showStep(2));
+	document.getElementById('back-to-step-1').addEventListener('click', () => showStep(1));
+	document.getElementById('next-to-step-3').addEventListener('click', () => showStep(3));
+	document.getElementById('back-to-step-2').addEventListener('click', () => showStep(2));
+	document.getElementById('create-another').addEventListener('click', () => {
+		selectedSections = { colors: true, typography: true, spacing: true };
+		loadPreview();
+		showStep(1);
+	});
+
+	function runCreate() {
+		const createLoading = document.getElementById('create-loading');
+		const resultSummary = document.getElementById('result-summary');
+		const resultWarningsSection = document.getElementById('result-warnings-section');
+		const backButton = document.getElementById('back-to-step-2');
+		const createAnotherButton = document.getElementById('create-another');
+
+		createLoading.style.display = 'flex';
+		resultSummary.style.display = 'none';
+		resultWarningsSection.style.display = 'none';
+		backButton.style.display = 'none';
+		createAnotherButton.style.display = 'none';
+
+		const options = {
+			sections: selectedSections,
+			conflictStrategy: document.getElementById('conflict-strategy').value
+		};
+
+		parent.postMessage({
+			pluginMessage: { type: "CREATE_FROM_SCHEMA", options }
+		}, "*");
+	}
+
+	// Message handling
+	window.onmessage = ({ data: { pluginMessage } }) => {
+		if (pluginMessage.type === "PREVIEW_SCHEMA_CREATE_RESULT") {
+			const loading = document.getElementById('sections-loading');
+			if (loading) loading.style.display = 'none';
+
+			if (pluginMessage.error) {
+				document.getElementById('section-list').innerHTML =
+					`<div class="info-banner" style="color: #990000;">${pluginMessage.error}</div>`;
+				return;
+			}
+
+			previewData = pluginMessage.preview;
+			renderSections(previewData.sections);
+		} else if (pluginMessage.type === "CREATE_FROM_SCHEMA_RESULT") {
+			const createLoading = document.getElementById('create-loading');
+			const resultSummary = document.getElementById('result-summary');
+			const resultWarningsSection = document.getElementById('result-warnings-section');
+			const resultWarningsList = document.getElementById('result-warnings-list');
+			const backButton = document.getElementById('back-to-step-2');
+			const createAnotherButton = document.getElementById('create-another');
+
+			createLoading.style.display = 'none';
+
+			if (pluginMessage.error) {
+				resultSummary.style.display = 'block';
+				resultSummary.className = 'result-summary error';
+				resultSummary.innerHTML = `<div style="color: #990000;"><strong>Creation failed:</strong> ${pluginMessage.error}</div>`;
+				backButton.style.display = 'inline';
+				return;
+			}
+
+			const result = pluginMessage.result;
+
+			resultSummary.style.display = 'block';
+			resultSummary.className = `result-summary ${result.success ? 'success' : 'error'}`;
+
+			document.getElementById('collections-created').textContent = result.collectionsCreated;
+			document.getElementById('variables-created').textContent = result.variablesCreated;
+			document.getElementById('variables-skipped').textContent = result.skipped;
+
+			// Show created collections
+			const collectionsDiv = document.getElementById('result-collections');
+			collectionsDiv.innerHTML = '';
+
+			if (result.collections.length > 0) {
+				result.collections.forEach(c => {
+					const item = document.createElement('div');
+					item.className = 'result-collection';
+					item.innerHTML = `<span>${c.name}</span><span>${c.variableCount} variables</span>`;
+					collectionsDiv.appendChild(item);
+				});
+			}
+
+			// Show warnings
+			if (result.warnings.length > 0) {
+				resultWarningsSection.style.display = 'block';
+				resultWarningsList.innerHTML = result.warnings.map(w => `<li>${w}</li>`).join('');
+			}
+
+			createAnotherButton.style.display = 'inline';
+
+			// Update info text
+			document.getElementById('step-3-info').textContent =
+				result.success ? 'Variables created successfully!' : 'Creation completed with errors.';
+		}
+	};
+
+	// Initial load
+	loadPreview();
+</script>

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
   "networkAccess": {
       "allowedDomains": ["https://cdnjs.cloudflare.com",
       "https://schemas.wp.org/trunk/theme.json",
+      "https://raw.githubusercontent.com",
       "https://fonts.googleapis.com",
       "https://fonts.gstatic.com"
     ]
@@ -15,11 +16,13 @@
   "menu": [
     { "command": "export", "name": "Export to theme.json" },
     { "command": "import", "name": "Import from theme.json" },
+    { "command": "create-from-schema", "name": "Create from Schema" },
     { "command": "css-vars", "name": "Apply CSS Variable Syntax" }
   ],
   "ui": {
     "export": "export.html",
     "import": "import.html",
+    "create-from-schema": "create-from-schema.html",
     "css-vars": "css-vars.html"
   },
   "documentAccess": "dynamic-page"

--- a/src/code.ts
+++ b/src/code.ts
@@ -7,6 +7,7 @@ import { applyCssVarSyntaxToVariables } from './utils/figma-variables';
 import { getDetectedBlocks } from './collections/processors/wp-blocks';
 import { isWordPressBlocksCollection, extractWordPressBlockName, isCoreBlock } from './utils/index';
 import { importFromThemeJSON, validateThemeJSON, previewImport, checkExistingCollections, ImportOptions } from './import/index';
+import { createFromSchema, previewSchemaCreate, checkExistingSchemaCollections, SchemaCreateOptions } from './schema/index';
 
 figma.ui.onmessage = async (e) => {
 	console.log("code received message", e);
@@ -171,6 +172,55 @@ figma.ui.onmessage = async (e) => {
 			});
 		}
 	}
+	// ==========================================================================
+	// Schema-based Creation Message Handlers
+	// ==========================================================================
+	else if (e.type === "PREVIEW_SCHEMA_CREATE") {
+		// Preview what schema-based creation will produce
+		try {
+			const { options } = e;
+			const preview = await previewSchemaCreate(options || {});
+			figma.ui.postMessage({
+				type: "PREVIEW_SCHEMA_CREATE_RESULT",
+				preview
+			});
+		} catch (error) {
+			figma.ui.postMessage({
+				type: "PREVIEW_SCHEMA_CREATE_RESULT",
+				error: error instanceof Error ? error.message : "Preview failed"
+			});
+		}
+	} else if (e.type === "CREATE_FROM_SCHEMA") {
+		// Create variables from schema
+		try {
+			const options: SchemaCreateOptions = e.options;
+			const result = await createFromSchema(options);
+			figma.ui.postMessage({
+				type: "CREATE_FROM_SCHEMA_RESULT",
+				result
+			});
+		} catch (error) {
+			figma.ui.postMessage({
+				type: "CREATE_FROM_SCHEMA_RESULT",
+				error: error instanceof Error ? error.message : "Creation failed"
+			});
+		}
+	} else if (e.type === "CHECK_SCHEMA_COLLECTIONS") {
+		// Check for existing collections that would conflict
+		try {
+			const { collectionNames } = e;
+			const existing = await checkExistingSchemaCollections(collectionNames || []);
+			figma.ui.postMessage({
+				type: "CHECK_SCHEMA_COLLECTIONS_RESULT",
+				existing
+			});
+		} catch (error) {
+			figma.ui.postMessage({
+				type: "CHECK_SCHEMA_COLLECTIONS_RESULT",
+				error: error instanceof Error ? error.message : "Check failed"
+			});
+		}
+	}
 };
 
 if (figma.command === "export") {
@@ -181,6 +231,12 @@ if (figma.command === "export") {
 	});
 } else if (figma.command === "import") {
 	figma.showUI(__uiFiles__["import"], {
+		width: 600,
+		height: 650,
+		themeColors: true,
+	});
+} else if (figma.command === "create-from-schema") {
+	figma.showUI(__uiFiles__["create-from-schema"], {
 		width: 600,
 		height: 650,
 		themeColors: true,

--- a/src/schema/creators/index.ts
+++ b/src/schema/creators/index.ts
@@ -1,0 +1,109 @@
+/**
+ * Schema Creator Registry
+ *
+ * Coordinates the creation of Figma variable collections from schema placeholders.
+ */
+
+import { SchemaCreateOptions, CreatorResult, GetOrCreateCollection } from '../types';
+import { createColorCollection } from './wp-settings-colors';
+import { createTypographyCollection } from './wp-settings-typography';
+import { createSpacingCollection } from './wp-settings-spacing';
+
+/**
+ * Process all enabled sections and create collections
+ */
+export async function processAllSections(
+	options: SchemaCreateOptions
+): Promise<CreatorResult> {
+	const result: CreatorResult = {
+		collectionsCreated: 0,
+		variablesCreated: 0,
+		skipped: 0,
+		collections: [],
+		warnings: [],
+		errors: []
+	};
+
+	// Get existing collections for conflict detection
+	const existingCollections = await figma.variables.getLocalVariableCollectionsAsync();
+	const existingNames = new Map(
+		existingCollections.map(c => [c.name.toLowerCase(), c])
+	);
+
+	// Helper to get or create a collection
+	const getOrCreateCollection: GetOrCreateCollection = async (name: string) => {
+		const existing = existingNames.get(name.toLowerCase());
+
+		if (existing) {
+			if (options.conflictStrategy === 'skip') {
+				return null;
+			}
+			if (options.conflictStrategy === 'rename') {
+				// Create with a new name
+				let suffix = 1;
+				let newName = `${name} (${suffix})`;
+				while (existingNames.has(newName.toLowerCase())) {
+					suffix++;
+					newName = `${name} (${suffix})`;
+				}
+				const collection = figma.variables.createVariableCollection(newName);
+				result.warnings.push(`Renamed collection: ${name} → ${newName}`);
+				return collection;
+			}
+			// Overwrite - return existing to add variables to it
+			return existing;
+		}
+
+		return figma.variables.createVariableCollection(name);
+	};
+
+	// Process sections in order
+
+	// 1. Colors
+	if (options.sections.colors) {
+		try {
+			const createResult = await createColorCollection(options, getOrCreateCollection);
+			mergeResults(result, createResult);
+		} catch (error) {
+			result.errors.push(`Colors: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	// 2. Typography
+	if (options.sections.typography) {
+		try {
+			const createResult = await createTypographyCollection(options, getOrCreateCollection);
+			mergeResults(result, createResult);
+		} catch (error) {
+			result.errors.push(`Typography: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	// 3. Spacing
+	if (options.sections.spacing) {
+		try {
+			const createResult = await createSpacingCollection(options, getOrCreateCollection);
+			mergeResults(result, createResult);
+		} catch (error) {
+			result.errors.push(`Spacing: ${error instanceof Error ? error.message : 'Unknown error'}`);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Merge creator results into the main result
+ */
+function mergeResults(target: CreatorResult, source: CreatorResult): void {
+	target.collectionsCreated += source.collectionsCreated;
+	target.variablesCreated += source.variablesCreated;
+	target.skipped += source.skipped;
+	target.collections.push(...source.collections);
+	target.warnings.push(...source.warnings);
+	target.errors.push(...source.errors);
+}
+
+export { createColorCollection } from './wp-settings-colors';
+export { createTypographyCollection } from './wp-settings-typography';
+export { createSpacingCollection } from './wp-settings-spacing';

--- a/src/schema/creators/wp-settings-colors.ts
+++ b/src/schema/creators/wp-settings-colors.ts
@@ -1,0 +1,168 @@
+/**
+ * Color Palette Collection Creator (Schema-based)
+ *
+ * Creates a "wp.settings.colors" collection from placeholder colors.
+ */
+
+import { CreatorResult, GetOrCreateCollection, ColorPlaceholder, SchemaCreateOptions } from '../types';
+import { DEFAULT_COLORS, COLLECTION_NAMES } from '../placeholders';
+import { getExistingVariableNames } from '../detector';
+
+/**
+ * Parse hex color to Figma RGBA
+ */
+function hexToFigmaRgba(hex: string): RGBA {
+	// Remove # if present
+	const cleanHex = hex.replace('#', '');
+
+	// Parse hex values
+	const r = parseInt(cleanHex.substring(0, 2), 16) / 255;
+	const g = parseInt(cleanHex.substring(2, 4), 16) / 255;
+	const b = parseInt(cleanHex.substring(4, 6), 16) / 255;
+
+	return { r, g, b, a: 1 };
+}
+
+/**
+ * Create wp.settings.colors collection from placeholder values
+ */
+export async function createColorCollection(
+	options: SchemaCreateOptions,
+	getOrCreateCollection: GetOrCreateCollection
+): Promise<CreatorResult> {
+	const result: CreatorResult = {
+		collectionsCreated: 0,
+		variablesCreated: 0,
+		skipped: 0,
+		collections: [],
+		warnings: [],
+		errors: []
+	};
+
+	const collectionName = COLLECTION_NAMES.colors;
+	const colors = options.customPlaceholders?.colors || DEFAULT_COLORS;
+
+	if (colors.length === 0) {
+		result.warnings.push('No colors defined for creation');
+		return result;
+	}
+
+	// Get or create collection
+	const collection = await getOrCreateCollection(collectionName);
+	if (!collection) {
+		result.warnings.push(`Skipped ${collectionName} collection (conflict strategy: skip)`);
+		return result;
+	}
+
+	// Track if we created a new collection
+	const isNewCollection = collection.variableIds.length === 0;
+	if (isNewCollection) {
+		result.collectionsCreated++;
+	}
+
+	// Get existing variables to check for duplicates
+	const existingVariables = await getExistingVariableNames(collection);
+
+	// Get mode ID (use first mode)
+	const modeId = collection.modes[0].modeId;
+
+	// Create variables from placeholders
+	for (const colorDef of colors) {
+		const { name, slug, color } = colorDef;
+		const variableName = slug;
+
+		// Check if already exists
+		if (existingVariables.has(variableName.toLowerCase())) {
+			if (options.conflictStrategy !== 'overwrite') {
+				result.skipped++;
+				continue;
+			}
+		}
+
+		try {
+			let variable: Variable;
+
+			// Check if variable already exists in collection
+			const existingVar = await findVariableByName(collection, variableName);
+
+			if (existingVar && options.conflictStrategy === 'overwrite') {
+				variable = existingVar;
+			} else if (existingVar) {
+				result.skipped++;
+				continue;
+			} else {
+				variable = figma.variables.createVariable(
+					variableName,
+					collection,
+					'COLOR'
+				);
+				result.variablesCreated++;
+			}
+
+			// Set description to the display name
+			variable.description = name;
+
+			// Parse and set the color value
+			try {
+				const rgba = hexToFigmaRgba(color);
+				variable.setValueForMode(modeId, rgba);
+			} catch (colorError) {
+				result.warnings.push(`Invalid color value for ${name} (${slug}): ${color}`);
+			}
+		} catch (error) {
+			result.warnings.push(
+				`Failed to create color ${name}: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	result.collections.push({
+		name: collection.name,
+		id: collection.id,
+		variableCount: result.variablesCreated
+	});
+
+	return result;
+}
+
+/**
+ * Find a variable by name in a collection
+ */
+async function findVariableByName(
+	collection: VariableCollection,
+	name: string
+): Promise<Variable | null> {
+	for (const varId of collection.variableIds) {
+		const variable = await figma.variables.getVariableByIdAsync(varId);
+		if (variable && variable.name.toLowerCase() === name.toLowerCase()) {
+			return variable;
+		}
+	}
+	return null;
+}
+
+/**
+ * Get preview of colors that would be created
+ */
+export function getColorPreview(
+	existingVariables: Set<string>,
+	customPlaceholders?: ColorPlaceholder[]
+): {
+	total: number;
+	existing: number;
+	variables: Array<{ name: string; displayName: string; value: string; exists: boolean }>;
+} {
+	const colors = customPlaceholders || DEFAULT_COLORS;
+	const variables = colors.map(c => ({
+		name: c.slug,
+		displayName: c.name,
+		value: c.color,
+		exists: existingVariables.has(c.slug.toLowerCase())
+	}));
+
+	return {
+		total: colors.length,
+		existing: variables.filter(v => v.exists).length,
+		variables
+	};
+}

--- a/src/schema/creators/wp-settings-spacing.ts
+++ b/src/schema/creators/wp-settings-spacing.ts
@@ -1,0 +1,175 @@
+/**
+ * Spacing Collection Creator (Schema-based)
+ *
+ * Creates a "wp.settings.spacing" collection from placeholder spacing values.
+ */
+
+import { CreatorResult, GetOrCreateCollection, SpacingPlaceholder, SchemaCreateOptions } from '../types';
+import { DEFAULT_SPACING, COLLECTION_NAMES } from '../placeholders';
+import { getExistingVariableNames } from '../detector';
+
+/**
+ * Parse CSS size value to number (in pixels)
+ */
+function parseCssSize(value: string): number {
+	const match = value.match(/^([\d.]+)(px|rem|em)?$/i);
+	if (!match) {
+		throw new Error(`Invalid size value: ${value}`);
+	}
+
+	const num = parseFloat(match[1]);
+	const unit = (match[2] || 'px').toLowerCase();
+
+	switch (unit) {
+		case 'rem':
+		case 'em':
+			return num * 16; // Assume 16px base
+		case 'px':
+		default:
+			return num;
+	}
+}
+
+/**
+ * Create wp.settings.spacing collection from placeholder values
+ */
+export async function createSpacingCollection(
+	options: SchemaCreateOptions,
+	getOrCreateCollection: GetOrCreateCollection
+): Promise<CreatorResult> {
+	const result: CreatorResult = {
+		collectionsCreated: 0,
+		variablesCreated: 0,
+		skipped: 0,
+		collections: [],
+		warnings: [],
+		errors: []
+	};
+
+	const collectionName = COLLECTION_NAMES.spacing;
+	const spacingSizes = options.customPlaceholders?.spacing || DEFAULT_SPACING;
+
+	if (spacingSizes.length === 0) {
+		result.warnings.push('No spacing sizes defined for creation');
+		return result;
+	}
+
+	// Get or create collection
+	const collection = await getOrCreateCollection(collectionName);
+	if (!collection) {
+		result.warnings.push(`Skipped ${collectionName} collection (conflict strategy: skip)`);
+		return result;
+	}
+
+	// Track if we created a new collection
+	const isNewCollection = collection.variableIds.length === 0;
+	if (isNewCollection) {
+		result.collectionsCreated++;
+	}
+
+	// Get existing variables to check for duplicates
+	const existingVariables = await getExistingVariableNames(collection);
+
+	// Get mode ID (use first mode)
+	const modeId = collection.modes[0].modeId;
+
+	// Create variables from placeholders
+	for (const spacingDef of spacingSizes) {
+		const { name, slug, size } = spacingDef;
+		const variableName = slug;
+
+		// Check if already exists
+		if (existingVariables.has(variableName.toLowerCase())) {
+			if (options.conflictStrategy !== 'overwrite') {
+				result.skipped++;
+				continue;
+			}
+		}
+
+		try {
+			let variable: Variable;
+
+			// Check if variable already exists in collection
+			const existingVar = await findVariableByName(collection, variableName);
+
+			if (existingVar && options.conflictStrategy === 'overwrite') {
+				variable = existingVar;
+			} else if (existingVar) {
+				result.skipped++;
+				continue;
+			} else {
+				variable = figma.variables.createVariable(
+					variableName,
+					collection,
+					'FLOAT'
+				);
+				result.variablesCreated++;
+			}
+
+			// Set description to the display name
+			variable.description = name;
+
+			// Parse and set the size value
+			try {
+				const numericValue = parseCssSize(size);
+				variable.setValueForMode(modeId, numericValue);
+			} catch (sizeError) {
+				result.warnings.push(`Invalid size value for ${name} (${slug}): ${size}`);
+			}
+		} catch (error) {
+			result.warnings.push(
+				`Failed to create spacing ${name}: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	result.collections.push({
+		name: collection.name,
+		id: collection.id,
+		variableCount: result.variablesCreated
+	});
+
+	return result;
+}
+
+/**
+ * Find a variable by name in a collection
+ */
+async function findVariableByName(
+	collection: VariableCollection,
+	name: string
+): Promise<Variable | null> {
+	for (const varId of collection.variableIds) {
+		const variable = await figma.variables.getVariableByIdAsync(varId);
+		if (variable && variable.name.toLowerCase() === name.toLowerCase()) {
+			return variable;
+		}
+	}
+	return null;
+}
+
+/**
+ * Get preview of spacing that would be created
+ */
+export function getSpacingPreview(
+	existingVariables: Set<string>,
+	customPlaceholders?: SpacingPlaceholder[]
+): {
+	total: number;
+	existing: number;
+	variables: Array<{ name: string; displayName: string; value: string; exists: boolean }>;
+} {
+	const spacing = customPlaceholders || DEFAULT_SPACING;
+	const variables = spacing.map(sp => ({
+		name: sp.slug,
+		displayName: sp.name,
+		value: sp.size,
+		exists: existingVariables.has(sp.slug.toLowerCase())
+	}));
+
+	return {
+		total: spacing.length,
+		existing: variables.filter(v => v.exists).length,
+		variables
+	};
+}

--- a/src/schema/creators/wp-settings-typography.ts
+++ b/src/schema/creators/wp-settings-typography.ts
@@ -1,0 +1,178 @@
+/**
+ * Typography Collection Creator (Schema-based)
+ *
+ * Creates a "wp.settings.typography" collection from placeholder font sizes.
+ */
+
+import { CreatorResult, GetOrCreateCollection, FontSizePlaceholder, SchemaCreateOptions } from '../types';
+import { DEFAULT_FONT_SIZES, COLLECTION_NAMES } from '../placeholders';
+import { getExistingVariableNames } from '../detector';
+
+/**
+ * Parse CSS size value to number (in pixels)
+ */
+function parseCssSize(value: string): number {
+	const match = value.match(/^([\d.]+)(px|rem|em)?$/i);
+	if (!match) {
+		throw new Error(`Invalid size value: ${value}`);
+	}
+
+	const num = parseFloat(match[1]);
+	const unit = (match[2] || 'px').toLowerCase();
+
+	switch (unit) {
+		case 'rem':
+		case 'em':
+			return num * 16; // Assume 16px base
+		case 'px':
+		default:
+			return num;
+	}
+}
+
+/**
+ * Create wp.settings.typography collection from placeholder values
+ */
+export async function createTypographyCollection(
+	options: SchemaCreateOptions,
+	getOrCreateCollection: GetOrCreateCollection
+): Promise<CreatorResult> {
+	const result: CreatorResult = {
+		collectionsCreated: 0,
+		variablesCreated: 0,
+		skipped: 0,
+		collections: [],
+		warnings: [],
+		errors: []
+	};
+
+	const collectionName = COLLECTION_NAMES.typography;
+	const fontSizes = options.customPlaceholders?.fontSizes || DEFAULT_FONT_SIZES;
+
+	if (fontSizes.length === 0) {
+		result.warnings.push('No font sizes defined for creation');
+		return result;
+	}
+
+	// Get or create collection
+	const collection = await getOrCreateCollection(collectionName);
+	if (!collection) {
+		result.warnings.push(`Skipped ${collectionName} collection (conflict strategy: skip)`);
+		return result;
+	}
+
+	// Track if we created a new collection
+	const isNewCollection = collection.variableIds.length === 0;
+	if (isNewCollection) {
+		result.collectionsCreated++;
+	}
+
+	// Get existing variables to check for duplicates
+	const existingVariables = await getExistingVariableNames(collection);
+
+	// Get mode ID (use first mode)
+	const modeId = collection.modes[0].modeId;
+
+	// Create variables from placeholders
+	for (const sizeDef of fontSizes) {
+		const { name, slug, size } = sizeDef;
+		const variableName = `fontSize/${slug}`;
+
+		// Check if already exists
+		if (existingVariables.has(variableName.toLowerCase())) {
+			if (options.conflictStrategy !== 'overwrite') {
+				result.skipped++;
+				continue;
+			}
+		}
+
+		try {
+			let variable: Variable;
+
+			// Check if variable already exists in collection
+			const existingVar = await findVariableByName(collection, variableName);
+
+			if (existingVar && options.conflictStrategy === 'overwrite') {
+				variable = existingVar;
+			} else if (existingVar) {
+				result.skipped++;
+				continue;
+			} else {
+				variable = figma.variables.createVariable(
+					variableName,
+					collection,
+					'FLOAT'
+				);
+				result.variablesCreated++;
+			}
+
+			// Set description to the display name
+			variable.description = name;
+
+			// Parse and set the size value
+			try {
+				const numericValue = parseCssSize(size);
+				variable.setValueForMode(modeId, numericValue);
+			} catch (sizeError) {
+				result.warnings.push(`Invalid size value for ${name} (${slug}): ${size}`);
+			}
+		} catch (error) {
+			result.warnings.push(
+				`Failed to create font size ${name}: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	result.collections.push({
+		name: collection.name,
+		id: collection.id,
+		variableCount: result.variablesCreated
+	});
+
+	return result;
+}
+
+/**
+ * Find a variable by name in a collection
+ */
+async function findVariableByName(
+	collection: VariableCollection,
+	name: string
+): Promise<Variable | null> {
+	for (const varId of collection.variableIds) {
+		const variable = await figma.variables.getVariableByIdAsync(varId);
+		if (variable && variable.name.toLowerCase() === name.toLowerCase()) {
+			return variable;
+		}
+	}
+	return null;
+}
+
+/**
+ * Get preview of font sizes that would be created
+ */
+export function getTypographyPreview(
+	existingVariables: Set<string>,
+	customPlaceholders?: FontSizePlaceholder[]
+): {
+	total: number;
+	existing: number;
+	variables: Array<{ name: string; displayName: string; value: string; exists: boolean }>;
+} {
+	const fontSizes = customPlaceholders || DEFAULT_FONT_SIZES;
+	const variables = fontSizes.map(fs => {
+		const varName = `fontSize/${fs.slug}`;
+		return {
+			name: varName,
+			displayName: fs.name,
+			value: fs.size,
+			exists: existingVariables.has(varName.toLowerCase())
+		};
+	});
+
+	return {
+		total: fontSizes.length,
+		existing: variables.filter(v => v.exists).length,
+		variables
+	};
+}

--- a/src/schema/detector.ts
+++ b/src/schema/detector.ts
@@ -1,0 +1,135 @@
+/**
+ * Existing Variable Detection
+ *
+ * Checks for existing collections and variables to enable smart conflict handling.
+ */
+
+import { ExistingCollectionInfo } from './types';
+import { COLLECTION_NAMES } from './placeholders';
+
+/**
+ * Detect existing collections that would conflict with schema creation
+ */
+export async function detectExistingCollections(): Promise<Map<string, ExistingCollectionInfo>> {
+	const collections = await figma.variables.getLocalVariableCollectionsAsync();
+	const result = new Map<string, ExistingCollectionInfo>();
+
+	for (const collection of collections) {
+		const lowerName = collection.name.toLowerCase();
+
+		// Check if this matches any of our target collection names
+		for (const [key, targetName] of Object.entries(COLLECTION_NAMES)) {
+			if (lowerName === targetName.toLowerCase()) {
+				const existingVariables: string[] = [];
+
+				// Get all variable names in this collection
+				for (const varId of collection.variableIds) {
+					const variable = await figma.variables.getVariableByIdAsync(varId);
+					if (variable) {
+						existingVariables.push(variable.name.toLowerCase());
+					}
+				}
+
+				result.set(key, {
+					name: collection.name,
+					id: collection.id,
+					variableCount: collection.variableIds.length,
+					existingVariables
+				});
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Check if a specific collection exists
+ */
+export async function collectionExists(collectionName: string): Promise<{
+	exists: boolean;
+	collection?: VariableCollection;
+	variableNames?: string[];
+}> {
+	const collections = await figma.variables.getLocalVariableCollectionsAsync();
+	const existing = collections.find(
+		c => c.name.toLowerCase() === collectionName.toLowerCase()
+	);
+
+	if (!existing) {
+		return { exists: false };
+	}
+
+	const variableNames: string[] = [];
+	for (const varId of existing.variableIds) {
+		const variable = await figma.variables.getVariableByIdAsync(varId);
+		if (variable) {
+			variableNames.push(variable.name.toLowerCase());
+		}
+	}
+
+	return {
+		exists: true,
+		collection: existing,
+		variableNames
+	};
+}
+
+/**
+ * Get existing variable names for a collection
+ */
+export async function getExistingVariableNames(collection: VariableCollection): Promise<Set<string>> {
+	const names = new Set<string>();
+
+	for (const varId of collection.variableIds) {
+		const variable = await figma.variables.getVariableByIdAsync(varId);
+		if (variable) {
+			names.add(variable.name.toLowerCase());
+		}
+	}
+
+	return names;
+}
+
+/**
+ * Check which variables from a list already exist in a collection
+ */
+export async function checkExistingVariables(
+	collectionName: string,
+	variableSlugs: string[]
+): Promise<{
+	collectionExists: boolean;
+	collectionId?: string;
+	existingVariables: string[];
+	missingVariables: string[];
+}> {
+	const check = await collectionExists(collectionName);
+
+	if (!check.exists || !check.variableNames) {
+		return {
+			collectionExists: false,
+			existingVariables: [],
+			missingVariables: variableSlugs
+		};
+	}
+
+	const existingSet = new Set(check.variableNames);
+	const existing: string[] = [];
+	const missing: string[] = [];
+
+	for (const slug of variableSlugs) {
+		if (existingSet.has(slug.toLowerCase())) {
+			existing.push(slug);
+		} else {
+			missing.push(slug);
+		}
+	}
+
+	return {
+		collectionExists: true,
+		collectionId: check.collection?.id,
+		existingVariables: existing,
+		missingVariables: missing
+	};
+}

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,0 +1,238 @@
+/**
+ * Schema-based Variable Creation
+ *
+ * Main entry point for creating Figma variables from WordPress theme.json schema.
+ */
+
+import {
+	SchemaCreateOptions,
+	SchemaCreateResult,
+	SchemaPreview,
+	SectionPreview,
+	ExistingCollectionInfo
+} from './types';
+import { processAllSections } from './creators/index';
+import { detectExistingCollections, collectionExists } from './detector';
+import { COLLECTION_NAMES, SECTION_DISPLAY_NAMES, getDefaultPlaceholders } from './placeholders';
+import { getColorPreview } from './creators/wp-settings-colors';
+import { getTypographyPreview } from './creators/wp-settings-typography';
+import { getSpacingPreview } from './creators/wp-settings-spacing';
+
+const SCHEMA_URL = 'https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json';
+
+/**
+ * Fetch the WordPress theme.json schema
+ * Returns null if fetch fails (will use fallback placeholders)
+ */
+export async function fetchThemeJsonSchema(): Promise<any | null> {
+	try {
+		const response = await fetch(SCHEMA_URL);
+		if (!response.ok) {
+			console.warn(`Failed to fetch schema: ${response.status}`);
+			return null;
+		}
+		return await response.json();
+	} catch (error) {
+		console.warn('Failed to fetch theme.json schema, using fallback placeholders');
+		return null;
+	}
+}
+
+/**
+ * Create variables from schema placeholders
+ */
+export async function createFromSchema(options: SchemaCreateOptions): Promise<SchemaCreateResult> {
+	const result: SchemaCreateResult = {
+		success: false,
+		collectionsCreated: 0,
+		variablesCreated: 0,
+		skipped: 0,
+		errors: [],
+		warnings: [],
+		collections: []
+	};
+
+	try {
+		// Process all enabled sections
+		const creatorResult = await processAllSections(options);
+
+		// Merge results
+		result.collectionsCreated = creatorResult.collectionsCreated;
+		result.variablesCreated = creatorResult.variablesCreated;
+		result.skipped = creatorResult.skipped;
+		result.collections = creatorResult.collections;
+		result.warnings = creatorResult.warnings;
+		result.errors = creatorResult.errors;
+
+		// Determine success (no critical errors)
+		result.success = result.errors.length === 0;
+
+	} catch (error) {
+		result.errors.push(error instanceof Error ? error.message : 'Unknown error during creation');
+	}
+
+	return result;
+}
+
+/**
+ * Preview what schema-based creation will produce
+ */
+export async function previewSchemaCreate(
+	options: Partial<SchemaCreateOptions>
+): Promise<SchemaPreview> {
+	const sections: SectionPreview[] = [];
+	const existingCollections: ExistingCollectionInfo[] = [];
+	const warnings: string[] = [];
+
+	// Try to fetch schema (for future enhancement)
+	const schema = await fetchThemeJsonSchema();
+	const schemaSource: 'fetched' | 'fallback' = schema ? 'fetched' : 'fallback';
+
+	if (!schema) {
+		warnings.push('Using default placeholders (schema fetch failed or unavailable)');
+	}
+
+	// Detect existing collections
+	const existing = await detectExistingCollections();
+
+	// Get placeholders
+	const placeholders = getDefaultPlaceholders();
+
+	// Check each section
+	const sectionConfig = options.sections || { colors: true, typography: true, spacing: true };
+
+	// Colors section
+	if (sectionConfig.colors) {
+		const colorCheck = await collectionExists(COLLECTION_NAMES.colors);
+		const existingVars = colorCheck.variableNames ? new Set(colorCheck.variableNames) : new Set<string>();
+		const colorPreview = getColorPreview(existingVars, options.customPlaceholders?.colors);
+
+		sections.push({
+			id: 'colors',
+			collectionName: COLLECTION_NAMES.colors,
+			displayName: SECTION_DISPLAY_NAMES.colors,
+			variableCount: colorPreview.total,
+			existingCount: colorPreview.existing,
+			variables: colorPreview.variables.map(v => ({
+				name: v.name,
+				displayName: v.displayName,
+				type: 'COLOR' as const,
+				value: v.value,
+				exists: v.exists
+			})),
+			collectionExists: colorCheck.exists
+		});
+
+		if (colorCheck.exists) {
+			existingCollections.push({
+				name: COLLECTION_NAMES.colors,
+				id: colorCheck.collection?.id || '',
+				variableCount: colorCheck.variableNames?.length || 0,
+				existingVariables: colorCheck.variableNames || []
+			});
+		}
+	}
+
+	// Typography section
+	if (sectionConfig.typography) {
+		const typoCheck = await collectionExists(COLLECTION_NAMES.typography);
+		const existingVars = typoCheck.variableNames ? new Set(typoCheck.variableNames) : new Set<string>();
+		const typoPreview = getTypographyPreview(existingVars, options.customPlaceholders?.fontSizes);
+
+		sections.push({
+			id: 'typography',
+			collectionName: COLLECTION_NAMES.typography,
+			displayName: SECTION_DISPLAY_NAMES.typography,
+			variableCount: typoPreview.total,
+			existingCount: typoPreview.existing,
+			variables: typoPreview.variables.map(v => ({
+				name: v.name,
+				displayName: v.displayName,
+				type: 'FLOAT' as const,
+				value: v.value,
+				exists: v.exists
+			})),
+			collectionExists: typoCheck.exists
+		});
+
+		if (typoCheck.exists) {
+			existingCollections.push({
+				name: COLLECTION_NAMES.typography,
+				id: typoCheck.collection?.id || '',
+				variableCount: typoCheck.variableNames?.length || 0,
+				existingVariables: typoCheck.variableNames || []
+			});
+		}
+	}
+
+	// Spacing section
+	if (sectionConfig.spacing) {
+		const spacingCheck = await collectionExists(COLLECTION_NAMES.spacing);
+		const existingVars = spacingCheck.variableNames ? new Set(spacingCheck.variableNames) : new Set<string>();
+		const spacingPreview = getSpacingPreview(existingVars, options.customPlaceholders?.spacing);
+
+		sections.push({
+			id: 'spacing',
+			collectionName: COLLECTION_NAMES.spacing,
+			displayName: SECTION_DISPLAY_NAMES.spacing,
+			variableCount: spacingPreview.total,
+			existingCount: spacingPreview.existing,
+			variables: spacingPreview.variables.map(v => ({
+				name: v.name,
+				displayName: v.displayName,
+				type: 'FLOAT' as const,
+				value: v.value,
+				exists: v.exists
+			})),
+			collectionExists: spacingCheck.exists
+		});
+
+		if (spacingCheck.exists) {
+			existingCollections.push({
+				name: COLLECTION_NAMES.spacing,
+				id: spacingCheck.collection?.id || '',
+				variableCount: spacingCheck.variableNames?.length || 0,
+				existingVariables: spacingCheck.variableNames || []
+			});
+		}
+	}
+
+	return {
+		sections,
+		existingCollections,
+		warnings,
+		schemaSource
+	};
+}
+
+/**
+ * Check for existing collections that would conflict
+ */
+export async function checkExistingSchemaCollections(
+	collectionNames: string[]
+): Promise<ExistingCollectionInfo[]> {
+	const result: ExistingCollectionInfo[] = [];
+
+	for (const name of collectionNames) {
+		const check = await collectionExists(name);
+		if (check.exists && check.collection) {
+			result.push({
+				name: check.collection.name,
+				id: check.collection.id,
+				variableCount: check.variableNames?.length || 0,
+				existingVariables: check.variableNames || []
+			});
+		}
+	}
+
+	return result;
+}
+
+// Re-export types
+export type {
+	SchemaCreateOptions,
+	SchemaCreateResult,
+	SchemaPreview,
+	SchemaSectionConfig,
+	ExistingCollectionInfo
+} from './types';

--- a/src/schema/placeholders.ts
+++ b/src/schema/placeholders.ts
@@ -1,0 +1,95 @@
+/**
+ * Default Placeholder Values for Schema-based Variable Creation
+ *
+ * These are grayscale/neutral values that users can easily customize.
+ * Based on WordPress theme.json conventions.
+ */
+
+import { ColorPlaceholder, FontSizePlaceholder, SpacingPlaceholder, PlaceholderConfig } from './types';
+
+/**
+ * Default color placeholders - grayscale for easy customization
+ */
+export const DEFAULT_COLORS: ColorPlaceholder[] = [
+	{ name: 'Primary', slug: 'primary', color: '#333333' },
+	{ name: 'Secondary', slug: 'secondary', color: '#666666' },
+	{ name: 'Tertiary', slug: 'tertiary', color: '#999999' },
+	{ name: 'Foreground', slug: 'foreground', color: '#1a1a1a' },
+	{ name: 'Background', slug: 'background', color: '#ffffff' },
+	{ name: 'Contrast', slug: 'contrast', color: '#000000' },
+	{ name: 'Base', slug: 'base', color: '#f5f5f5' },
+	{ name: 'Accent', slug: 'accent', color: '#444444' }
+];
+
+/**
+ * Default font size placeholders - standard scale
+ */
+export const DEFAULT_FONT_SIZES: FontSizePlaceholder[] = [
+	{ name: 'Extra Small', slug: 'xs', size: '12px' },
+	{ name: 'Small', slug: 'sm', size: '14px' },
+	{ name: 'Medium', slug: 'md', size: '16px' },
+	{ name: 'Large', slug: 'lg', size: '20px' },
+	{ name: 'Extra Large', slug: 'xl', size: '24px' },
+	{ name: '2X Large', slug: 'xxl', size: '32px' },
+	{ name: '3X Large', slug: 'xxxl', size: '48px' }
+];
+
+/**
+ * Default spacing placeholders - WordPress 10-80 scale
+ */
+export const DEFAULT_SPACING: SpacingPlaceholder[] = [
+	{ name: '1 (Smallest)', slug: '10', size: '4px' },
+	{ name: '2', slug: '20', size: '8px' },
+	{ name: '3', slug: '30', size: '12px' },
+	{ name: '4', slug: '40', size: '16px' },
+	{ name: '5 (Medium)', slug: '50', size: '24px' },
+	{ name: '6', slug: '60', size: '32px' },
+	{ name: '7', slug: '70', size: '48px' },
+	{ name: '8 (Largest)', slug: '80', size: '64px' }
+];
+
+/**
+ * Get default placeholder configuration
+ */
+export function getDefaultPlaceholders(): PlaceholderConfig {
+	return {
+		colors: DEFAULT_COLORS,
+		fontSizes: DEFAULT_FONT_SIZES,
+		spacing: DEFAULT_SPACING
+	};
+}
+
+/**
+ * Merge custom placeholders with defaults
+ */
+export function mergePlaceholders(custom?: Partial<PlaceholderConfig>): PlaceholderConfig {
+	const defaults = getDefaultPlaceholders();
+
+	if (!custom) {
+		return defaults;
+	}
+
+	return {
+		colors: custom.colors || defaults.colors,
+		fontSizes: custom.fontSizes || defaults.fontSizes,
+		spacing: custom.spacing || defaults.spacing
+	};
+}
+
+/**
+ * Collection names for each section
+ */
+export const COLLECTION_NAMES = {
+	colors: 'wp.settings.colors',
+	typography: 'wp.settings.typography',
+	spacing: 'wp.settings.spacing'
+} as const;
+
+/**
+ * Display names for each section
+ */
+export const SECTION_DISPLAY_NAMES = {
+	colors: 'Colors',
+	typography: 'Typography',
+	spacing: 'Spacing'
+} as const;

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -1,0 +1,217 @@
+/**
+ * Schema-based Variable Creation Types
+ */
+
+/**
+ * Options for creating variables from schema
+ */
+export interface SchemaCreateOptions {
+	/** Which sections to create */
+	sections: SchemaSectionConfig;
+
+	/** How to handle collection name conflicts */
+	conflictStrategy: 'skip' | 'overwrite' | 'rename';
+
+	/** Create Desktop/Mobile modes for responsive values */
+	createFluidModes?: boolean;
+
+	/** Custom placeholder values (optional override) */
+	customPlaceholders?: Partial<PlaceholderConfig>;
+}
+
+/**
+ * Configuration for which schema sections to create
+ */
+export interface SchemaSectionConfig {
+	/** wp.settings.colors collection */
+	colors: boolean;
+
+	/** wp.settings.typography collection */
+	typography: boolean;
+
+	/** wp.settings.spacing collection */
+	spacing: boolean;
+}
+
+/**
+ * Configuration for placeholder values
+ */
+export interface PlaceholderConfig {
+	colors: ColorPlaceholder[];
+	fontSizes: FontSizePlaceholder[];
+	spacing: SpacingPlaceholder[];
+}
+
+/**
+ * Color placeholder definition
+ */
+export interface ColorPlaceholder {
+	/** Display name (e.g., "Primary") */
+	name: string;
+
+	/** Slug identifier (e.g., "primary") */
+	slug: string;
+
+	/** Hex color value (e.g., "#333333") */
+	color: string;
+}
+
+/**
+ * Font size placeholder definition
+ */
+export interface FontSizePlaceholder {
+	/** Display name (e.g., "Medium") */
+	name: string;
+
+	/** Slug identifier (e.g., "md") */
+	slug: string;
+
+	/** Size value (e.g., "16px") */
+	size: string;
+}
+
+/**
+ * Spacing placeholder definition
+ */
+export interface SpacingPlaceholder {
+	/** Display name (e.g., "4 (Medium)") */
+	name: string;
+
+	/** Slug identifier (e.g., "40") */
+	slug: string;
+
+	/** Size value (e.g., "16px") */
+	size: string;
+}
+
+/**
+ * Result of schema-based variable creation
+ */
+export interface SchemaCreateResult {
+	/** Whether creation completed without critical errors */
+	success: boolean;
+
+	/** Number of collections created */
+	collectionsCreated: number;
+
+	/** Number of variables created */
+	variablesCreated: number;
+
+	/** Number of items skipped */
+	skipped: number;
+
+	/** Critical error messages */
+	errors: string[];
+
+	/** Non-critical warning messages */
+	warnings: string[];
+
+	/** Details about created collections */
+	collections: SchemaCollectionResult[];
+}
+
+/**
+ * Information about a created collection
+ */
+export interface SchemaCollectionResult {
+	name: string;
+	id: string;
+	variableCount: number;
+}
+
+/**
+ * Preview of schema-based creation
+ */
+export interface SchemaPreview {
+	/** Sections that will be created */
+	sections: SectionPreview[];
+
+	/** Existing collections that conflict */
+	existingCollections: ExistingCollectionInfo[];
+
+	/** Warnings about potential issues */
+	warnings: string[];
+
+	/** Whether schema was fetched or using fallback */
+	schemaSource: 'fetched' | 'fallback';
+}
+
+/**
+ * Preview of a section to be created
+ */
+export interface SectionPreview {
+	/** Section identifier (colors, typography, spacing) */
+	id: string;
+
+	/** Collection name (e.g., "wp.settings.colors") */
+	collectionName: string;
+
+	/** Display name */
+	displayName: string;
+
+	/** Number of variables that will be created */
+	variableCount: number;
+
+	/** Number of variables that already exist (will be skipped) */
+	existingCount: number;
+
+	/** Preview of variables */
+	variables: SchemaVariablePreview[];
+
+	/** Whether this collection already exists */
+	collectionExists: boolean;
+}
+
+/**
+ * Preview of a variable from schema
+ */
+export interface SchemaVariablePreview {
+	/** Variable name/slug */
+	name: string;
+
+	/** Display name */
+	displayName: string;
+
+	/** Variable type */
+	type: 'COLOR' | 'FLOAT';
+
+	/** Placeholder value */
+	value: string;
+
+	/** Whether this variable already exists */
+	exists: boolean;
+}
+
+/**
+ * Information about an existing collection
+ */
+export interface ExistingCollectionInfo {
+	/** Collection name */
+	name: string;
+
+	/** Collection ID */
+	id: string;
+
+	/** Number of variables in the collection */
+	variableCount: number;
+
+	/** Names of existing variables */
+	existingVariables: string[];
+}
+
+/**
+ * Result from a creator function
+ */
+export interface CreatorResult {
+	collectionsCreated: number;
+	variablesCreated: number;
+	skipped: number;
+	collections: SchemaCollectionResult[];
+	warnings: string[];
+	errors: string[];
+}
+
+/**
+ * Function signature for getting or creating a collection
+ */
+export type GetOrCreateCollection = (name: string) => Promise<VariableCollection | null>;


### PR DESCRIPTION
Adds a new "Create from Schema" command that generates Figma variables based on the WordPress theme.json schema with placeholder values, perfect for projects starting fresh without existing theme.json files.

**Features:**
- Grayscale placeholder colors for easy customization
- Standard font size and spacing scales following WordPress conventions
- Detects existing variables and skips them by default (safe)
- Three conflict strategies: skip, overwrite, or rename collections
- Fetches WordPress schema with fallback to hardcoded defaults

**Collections Created:**
- `wp.settings.colors` - 8 grayscale colors
- `wp.settings.typography` - 7 font sizes (xs to xxxl)
- `wp.settings.spacing` - 8 spacing values (10-80 scale)

Users can select which collections to create and configure conflict handling through a three-step UI.