### PR TITLE
Support group-based block collections in wp.blocks

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -5,7 +5,7 @@ import { exportToJSON } from './export/index';
 import { getAllColorPresets } from './color/index';
 import { applyCssVarSyntaxToVariables } from './utils/figma-variables';
 import { getDetectedBlocks } from './collections/processors/wp-blocks';
-import { isWordPressBlocksCollection, extractWordPressBlockName, isCoreBlock } from './utils/index';
+import { isWordPressBlocksCollection, isGroupBasedBlocksCollection, extractWordPressBlockName, isCoreBlock } from './utils/index';
 import { importFromThemeJSON, validateThemeJSON, previewImport, checkExistingCollections, ImportOptions } from './import/index';
 import { createFromSchema, previewSchemaCreate, checkExistingSchemaCollections, SchemaCreateOptions } from './schema/index';
 
@@ -87,8 +87,21 @@ figma.ui.onmessage = async (e) => {
 				variableCount: collection.variableIds.length
 			}));
 
+			// For group-based wp.blocks collection, get variable names
+			let variableNames: string[] = [];
+			const wpBlocksCollection = collections.find(c => isGroupBasedBlocksCollection(c.name));
+			if (wpBlocksCollection) {
+				const variablePromises = wpBlocksCollection.variableIds.map(id =>
+					figma.variables.getVariableByIdAsync(id)
+				);
+				const variables = await Promise.all(variablePromises);
+				variableNames = variables
+					.filter((v): v is Variable => v !== null)
+					.map(v => v.name);
+			}
+
 			// Use the utility function to get detected blocks with badge info
-			const blocks = getDetectedBlocks(collectionData);
+			const blocks = getDetectedBlocks(collectionData, variableNames);
 
 			figma.ui.postMessage({
 				type: "BLOCKS_RESULT",

--- a/src/collections/processors/wp-blocks.ts
+++ b/src/collections/processors/wp-blocks.ts
@@ -2,9 +2,13 @@
  * WordPress Blocks Processor
  *
  * Handles wp.blocks.{namespace/block-name} collections for block-level styling.
- * Supports both WordPress core blocks and custom/third-party blocks.
+ * Also supports group-based structure where wp.blocks collection contains
+ * variables organized in namespace/block-name groups (e.g., core/cover, core/heading).
  *
- * Collection pattern: wp.blocks.{namespace}/{block-name}
+ * Collection patterns:
+ * - wp.blocks.{namespace}/{block-name} (legacy, namespace in collection name)
+ * - wp.blocks with groups like core/cover, core/heading (preferred, Figma-friendly)
+ *
  * Target: styles.blocks.{namespace/block-name}
  */
 
@@ -14,10 +18,14 @@ import {
   deepMerge,
   extractWordPressBlockName,
   isWordPressBlocksCollection,
+  isGroupBasedBlocksCollection,
   isCoreBlock,
+  formatValueWithUnits,
 } from "../../utils/index";
+import { rgbToHex } from "../../utils/color";
 import { validatePseudoSelectorsDeep } from "../../utils/pseudo-selectors";
 import type { CollectionProcessor } from "../types";
+import type { ExportOptions } from "../../types";
 
 /**
  * Stores validation warnings during processing
@@ -85,6 +93,13 @@ export const wpBlocksProcessor: CollectionProcessor = {
   matches: (name) => isWordPressBlocksCollection(name),
 
   process: async (collection, ctx, options) => {
+    // Check if this is the group-based wp.blocks collection
+    if (isGroupBasedBlocksCollection(collection.name)) {
+      await processGroupBasedBlocks(collection, ctx, options);
+      return;
+    }
+
+    // Legacy: handle wp.blocks.{namespace}/{block-name} collections
     const blockName = extractWordPressBlockName(collection.name);
     if (!blockName) return;
 
@@ -116,14 +131,114 @@ export const wpBlocksProcessor: CollectionProcessor = {
 };
 
 /**
+ * Process a group-based wp.blocks collection
+ * Variables are organized in groups like core/cover, core/heading
+ * Variable names follow pattern: {namespace}/{block-name}/{property-path}
+ * e.g., core/cover/color/background, core/heading/typography/fontSize
+ */
+async function processGroupBasedBlocks(
+  collection: any,
+  ctx: any,
+  options: ExportOptions | undefined
+) {
+  const { variableIds, modes } = collection;
+  const modeId = modes[0]?.modeId;
+  if (!modeId) return;
+
+  // Group variables by block name (first two segments: namespace/block-name)
+  const blockVariables: Map<string, Array<{ name: string; variable: any }>> = new Map();
+
+  for (const variableId of variableIds) {
+    const variable = await figma.variables.getVariableByIdAsync(variableId);
+    if (!variable) continue;
+
+    const parts = variable.name.split("/");
+    // Need at least namespace/block-name/property (3 parts minimum)
+    if (parts.length < 3) continue;
+
+    const blockName = `${parts[0]}/${parts[1]}`;
+    if (!blockVariables.has(blockName)) {
+      blockVariables.set(blockName, []);
+    }
+    blockVariables.get(blockName)!.push({ name: variable.name, variable });
+  }
+
+  // Ensure styles.blocks exists
+  ctx.theme.styles = ctx.theme.styles || {};
+  ctx.theme.styles.blocks = ctx.theme.styles.blocks || {};
+
+  // Process each block's variables
+  for (const [blockName, variables] of blockVariables) {
+    const blockData: Record<string, any> = {};
+
+    for (const { name, variable } of variables) {
+      const { resolvedType, valuesByMode } = variable;
+      const value = valuesByMode[modeId];
+
+      if (value === undefined || !["COLOR", "FLOAT"].includes(resolvedType)) continue;
+
+      // Get property path (everything after namespace/block-name)
+      const parts = name.split("/");
+      const propertyParts = parts.slice(2); // Skip namespace and block-name
+
+      // Build nested structure
+      let obj = blockData;
+      for (let i = 0; i < propertyParts.length - 1; i++) {
+        const part = propertyParts[i];
+        obj[part] = obj[part] || {};
+        obj = obj[part];
+      }
+
+      const leafName = propertyParts[propertyParts.length - 1];
+
+      // Handle the value
+      if (resolvedType === "COLOR") {
+        obj[leafName] = rgbToHex(value);
+      } else {
+        obj[leafName] = formatValueWithUnits(
+          propertyParts,
+          value,
+          options?.useRem,
+          options?.remCollections
+        );
+      }
+    }
+
+    const converted = convertObjectKeysToCamelCase(blockData);
+
+    // Validate pseudo-selectors
+    const warnings = validatePseudoSelectorsDeep(converted, `wp.blocks.${blockName}`);
+    if (warnings.length > 0) {
+      processingWarnings.push(...warnings);
+      warnings.forEach((w) => console.warn(`[wp-blocks] ${w}`));
+    }
+
+    const blockType = isCoreBlock(blockName) ? "core" : "custom";
+    console.log(`[wp-blocks] Processing ${blockType} block from groups: ${blockName}`);
+
+    // Deep merge into the block's styles
+    ctx.theme.styles.blocks[blockName] = deepMerge(
+      ctx.theme.styles.blocks[blockName] || {},
+      converted
+    );
+  }
+}
+
+/**
  * Gets all detected block collections from a list of collections
  * Useful for UI display of detected blocks with badges
  *
+ * Supports two patterns:
+ * 1. Legacy: collections named wp.blocks.{namespace}/{block-name}
+ * 2. Group-based: wp.blocks collection with variableNames containing block info
+ *
  * @param collections Array of collection objects with name property
+ * @param variableNames Optional array of variable names from wp.blocks collection (for group-based detection)
  * @returns Array of block info objects with name, isCoreBlock, and badge info
  */
 export function getDetectedBlocks(
-  collections: Array<{ name: string }>
+  collections: Array<{ name: string }>,
+  variableNames?: string[]
 ): Array<{
   blockName: string;
   collectionName: string;
@@ -137,10 +252,37 @@ export function getDetectedBlocks(
     badge: { label: string; cssClass: string };
   }> = [];
 
+  const addedBlockNames = new Set<string>();
+
   for (const collection of collections) {
-    if (isWordPressBlocksCollection(collection.name)) {
+    // Check for group-based wp.blocks collection
+    if (isGroupBasedBlocksCollection(collection.name) && variableNames && variableNames.length > 0) {
+      // Extract unique block names from variable names
+      // Variable names follow pattern: {namespace}/{block-name}/{property}
+      for (const varName of variableNames) {
+        const parts = varName.split("/");
+        if (parts.length >= 3) {
+          const blockName = `${parts[0]}/${parts[1]}`;
+          if (!addedBlockNames.has(blockName)) {
+            addedBlockNames.add(blockName);
+            const isCore = isCoreBlock(blockName);
+            blocks.push({
+              blockName,
+              collectionName: collection.name,
+              isCore,
+              badge: isCore
+                ? { label: "Core", cssClass: "badge-core" }
+                : { label: "Custom", cssClass: "badge-custom" },
+            });
+          }
+        }
+      }
+    }
+    // Legacy: wp.blocks.{namespace}/{block-name} pattern
+    else if (isWordPressBlocksCollection(collection.name) && !isGroupBasedBlocksCollection(collection.name)) {
       const blockName = extractWordPressBlockName(collection.name);
-      if (blockName) {
+      if (blockName && !addedBlockNames.has(blockName)) {
+        addedBlockNames.add(blockName);
         const isCore = isCoreBlock(blockName);
         blocks.push({
           blockName,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -331,14 +331,25 @@ export async function resolveColorValueToHex(
 
 /**
  * Checks if a collection name matches the WordPress blocks pattern
- * Matches: wp.blocks.core/button, wp.blocks.acf/hero, etc.
+ * Matches: wp.blocks (group-based) or wp.blocks.core/button, wp.blocks.acf/hero, etc.
  *
  * @param collectionName The name of the collection
  * @returns true if the collection should be treated as WordPress blocks styling
  */
 export function isWordPressBlocksCollection(collectionName: string): boolean {
-	const pattern = /^wp\.blocks\.[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*/i;
-	return pattern.test(collectionName);
+	// Match exact "wp.blocks" (group-based) or "wp.blocks.{namespace}/{block}" pattern
+	const exactMatch = /^wp\.blocks$/i.test(collectionName);
+	const namespacePattern = /^wp\.blocks\.[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*/i;
+	return exactMatch || namespacePattern.test(collectionName);
+}
+
+/**
+ * Checks if a collection is the exact "wp.blocks" collection (group-based structure)
+ * @param collectionName The name of the collection
+ * @returns true if this is the group-based wp.blocks collection
+ */
+export function isGroupBasedBlocksCollection(collectionName: string): boolean {
+	return /^wp\.blocks$/i.test(collectionName);
 }
 
 /**

--- a/wiki/BLOCKS-GUIDE.md
+++ b/wiki/BLOCKS-GUIDE.md
@@ -6,15 +6,39 @@ This guide explains how to create Figma variable collections that generate WordP
 
 WordPress theme.json allows you to define styles for specific blocks. This plugin supports creating block collections in Figma that export to the `styles.blocks` section of theme.json.
 
-## Collection Naming Pattern
+## Collection Naming Patterns
 
-Block collections must follow this naming convention:
+The plugin supports two patterns for organizing block styles:
+
+### Pattern 1: Group-Based (Recommended)
+
+Create a single `wp.blocks` collection and organize variables using Figma's group hierarchy:
+
+```
+Collection: wp.blocks
+  └── Group: core
+        ├── cover
+        │     └── color/background
+        │     └── color/text
+        └── heading
+              └── color/text
+```
+
+Variable naming pattern: `{namespace}/{block-name}/{property-path}`
+
+| Variable Name | Block Target | Property |
+|--------------|--------------|----------|
+| `core/cover/color/background` | `core/cover` | `color.background` |
+| `core/heading/color/text` | `core/heading` | `color.text` |
+| `acf/hero/spacing/padding` | `acf/hero` | `spacing.padding` |
+
+### Pattern 2: Collection-Per-Block (Legacy)
+
+Create separate collections for each block. Note: Figma interprets `/` in collection names as folder separators, which may cause issues.
 
 ```
 wp.blocks.{namespace}/{block-name}
 ```
-
-### Examples
 
 | Collection Name | Block Target |
 |-----------------|--------------|


### PR DESCRIPTION
## Summary

- Added support for Figma-friendly group-based block collections in the `wp.blocks` collection
- Blocks are now detected from variable names (e.g., `core/cover/color/background`)
- Both legacy and new group-based patterns are supported for backward compatibility

## Test Plan

- Verify that a `wp.blocks` collection with groups like `core/cover` and `core/heading` correctly exports blocks
- Confirm that the "Detected Blocks" UI shows the correct blocks with proper badges
- Test that exported theme.json contains the expected `styles.blocks` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)