### PR TITLE
Docs: refresh README and export guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<tr>
 		<td align="left" width="70%">
 			<strong>Figma to WordPress theme.json Exporter</strong><br />
-			A Figma plugin that converts design tokens and variables into WordPress theme.json format for seamless design-to-development workflows.
+			A Figma plugin that exports Figma variables to WordPress theme.json, imports theme.json back into Figma variables, and validates files for seamless design-to-development workflows.
 		</td>
 		<td align="center" width="30%">
 			<a href="https://github.com/linchpin/figma-to-wordpress-theme-json-exporter"><img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" alt="Maintained: yes" /></a>
@@ -22,9 +22,9 @@
 
 ## What is this plugin?
 
-This Figma plugin converts Figma design tokens and variables into WordPress theme.json format, placing all variables under the `settings.custom` section according to WordPress standards. It streamlines the design-to-development workflow for WordPress block themes.
+This Figma plugin powers a bidirectional workflow between Figma variables and WordPress theme.json. It exports design tokens into theme.json (placing custom variables under `settings.custom`), imports theme.json back into Figma variable collections, and validates theme.json files before you create or merge variables.
 
-> **Note:** This is a heavily modified fork of the original [10up Figma to theme.json plugin](https://github.com/10up/figma-to-wordpress-theme-json-exporter). Our version is opinionated toward Linchpin's approach to component export for design systems and client websites. If you need a more stable, general-purpose solution, consider the original 10up plugin.
+> **Note:** This is a heavily modified fork of the original [10up Figma to theme.json plugin](https://github.com/10up/figma-to-wordpress-theme-json-exporter). This fork has changed dramatically and is now the more stable, actively evolving track for our workflows. The 10up version remains supported and stays closer to the original scope.
 
 ## Why use this plugin?
 
@@ -37,6 +37,11 @@ This Figma plugin converts Figma design tokens and variables into WordPress them
 - **Typography presets** — Convert Figma text styles to WordPress typography presets with proper line height conversion (120% → 1.2).
 - **Color presets** — Generate WordPress color palette from Figma color variables with customizable selection via an interactive modal.
 - **Spacing presets** — Create WordPress spacing presets from Figma spacing variables with automatic fluid spacing detection.
+
+### **Bidirectional workflow**
+- **theme.json import** — Create Figma variable collections from `settings.custom`, `settings.color.palette`, `settings.typography.fontSizes`, and `settings.spacing.spacingSizes`.
+- **Preview + conflict checks** — See what collections and variables will be created before importing.
+- **Schema-aware validation** — Validates theme.json structure and schema (when available) with actionable errors and warnings.
 
 ### **Advanced features**
 - **Responsive/fluid variables** — Supports Desktop/Mobile mode pairs for fluid typography and spacing.
@@ -51,7 +56,9 @@ This Figma plugin converts Figma design tokens and variables into WordPress them
 
 ## Usage
 
-### Basic Export
+### Export to theme.json
+
+For a full export walkthrough, presets, and multi-file output details, see **[EXPORT-GUIDE.md](wiki/EXPORT-GUIDE.md)**.
 
 1. **To export Figma variables to theme.json:**
    - Go to Menu > Plugins > WordPress Theme.json Export > Export to theme.json
@@ -61,7 +68,7 @@ This Figma plugin converts Figma design tokens and variables into WordPress them
    - View the generated theme.json and additional style files in the plugin UI
    - Click "Download Theme Files" to save all files as a zip package
 
-### Advanced Options
+### Export Options
 
 2. **To merge with an existing theme.json:**
    - Click "Choose File" in the Base theme.json section
@@ -89,6 +96,27 @@ This Figma plugin converts Figma design tokens and variables into WordPress them
    - The plugin automatically detects spacing-related variables
    - Spacing presets are added to `settings.spacing.spacingSizes`
    - See [SPACING-GUIDE.md](wiki/SPACING-GUIDE.md) for detailed information
+
+### Import from theme.json
+
+1. **To create Figma variables from a theme.json file:**
+   - Go to Menu > Plugins > WordPress Theme.json Export > Import from theme.json
+   - Upload a theme.json file or paste JSON directly
+   - Review validation status and warnings before continuing
+   - Preview which collections and variables will be created
+   - Click "Import" to create variable collections in Figma
+
+2. **Importable sections (v3):**
+   - `settings.custom` → Primitives collection
+   - `settings.color.palette` → `wp.settings.colors` collection
+   - `settings.typography.fontSizes` → `wp.settings.typography` collection
+   - `settings.spacing.spacingSizes` → `wp.settings.spacing` collection
+
+### Validation
+
+- Validation runs before preview/import and reports errors and warnings inline.
+- Checks include required fields, version, structural rules, and schema validation (when the WordPress schema is reachable).
+- Warnings highlight missing sections, unsupported areas, or unknown top-level keys so you can fix issues before import.
 
 ### Plugin Interface Features
 
@@ -357,6 +385,7 @@ All files are packed into a single zip download for easy use in WordPress themes
 
 For comprehensive information on specific features, see these detailed guides:
 
+- **[EXPORT-GUIDE.md](wiki/EXPORT-GUIDE.md)** - Full export workflow, presets, and output details
 - **[INSTALL.md](wiki/INSTALL.md)** - Complete installation and setup instructions
 - **[NAMING-CONVENTIONS.md](wiki/NAMING-CONVENTIONS.md)** - Complete naming conventions reference for collections and variables
 - **[BLOCKS-GUIDE.md](wiki/BLOCKS-GUIDE.md)** - Block-level styling with `wp.blocks.*` collections

--- a/wiki/EXPORT-GUIDE.md
+++ b/wiki/EXPORT-GUIDE.md
@@ -1,0 +1,66 @@
+# Export Guide
+
+## Overview
+
+The exporter converts Figma variables into a WordPress theme.json v3 file. Custom variables are placed under `settings.custom`, with optional preset generation for typography, color, and spacing. When color modes or button variants are detected, the exporter writes additional style variation files and bundles everything into a zip.
+
+## Quick Start
+
+1. In Figma, go to Menu > Plugins > WordPress Theme.json Export > Export to theme.json.
+2. (Optional) Upload an existing theme.json to merge into.
+3. Choose export options (typography, color presets, spacing presets).
+4. Click "Export Variables".
+5. Review the generated files and click "Download Theme Files".
+
+## Export Options
+
+### Base theme merge
+
+- Upload a base theme.json to preserve existing settings and styles.
+- Variables from Figma are merged in, with custom variables placed under `settings.custom`.
+- Existing custom variables with the same name are updated.
+
+### Preset generation
+
+- Typography presets can be created from local text styles.
+- Color presets are created from color variables (with a selection modal).
+- Spacing presets are created from spacing variables and support fluid detection.
+
+See **[TYPOGRAPHY-GUIDE.md](TYPOGRAPHY-GUIDE.md)**, **[COLOR-PRESETS-GUIDE.md](COLOR-PRESETS-GUIDE.md)**, and **[SPACING-GUIDE.md](SPACING-GUIDE.md)** for detailed behavior.
+
+### Collection routing
+
+The exporter routes collections based on their names (for example, `wp.settings.*`, `wp.elements.*`, `wp.blocks.*`). Use the naming conventions guide to make sure collections end up in the intended theme.json sections.
+
+See **[NAMING-CONVENTIONS.md](NAMING-CONVENTIONS.md)** for the full mapping rules.
+
+### Responsive and fluid variables
+
+Collections with exactly two modes named "Desktop" and "Mobile" are treated as fluid variables, producing objects with `min` and `max` values. See **[FLUID-VARIABLES-GUIDE.md](FLUID-VARIABLES-GUIDE.md)** for setup details.
+
+### Color modes and button variants
+
+- Color collections with multiple modes can generate section style variations (`styles/section-*.json`).
+- Button variants in color collections can generate block style variations (`styles/button-*.json`).
+
+## Output Files
+
+Typical output:
+
+```
+wordpress-theme-files.zip
+├── theme.json
+└── styles/
+    ├── section-light.json
+    ├── section-dark.json
+    ├── button-secondary.json
+    └── button-tertiary.json
+```
+
+A single `theme.json` is produced when no variations are detected; otherwise, the exporter bundles multiple files into a zip for download.
+
+## Tips
+
+- Publish variables and keep collections organized for predictable output.
+- Use the preview panel to sanity check generated files before downloading.
+- When exporting WordPress blocks or elements, align collection names with the naming conventions guide.


### PR DESCRIPTION
Updates README to reflect export, import, and validation workflows. Adds a dedicated export guide in the wiki and links it from README.