### PR TITLE
Rename project to reflect bidirectional functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,10 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 - Initial private release.
 
-[Unreleased]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/main...develop
-[1.2.0]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/0c0de2a...5cca2ca
-[1.1.3]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/v1.1.2...0c0de2a
-[1.1.2]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/v1.1.1...v1.1.2
-[1.1.1]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/v1.1.0...v1.1.1
-[1.1.0]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/tree/v1.0.0
+[Unreleased]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/main...develop
+[1.2.0]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/0c0de2a...5cca2ca
+[1.1.3]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/v1.1.2...0c0de2a
+[1.1.2]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/linchpin/figma-wordpress-theme-json-sync/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/linchpin/figma-wordpress-theme-json-sync/tree/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,11 @@ Contributing isn't just writing code - it's anything that improves the project. 
 
 ### Reporting bugs
 
-If you're running into an issue, please take a look through [existing issues](https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/issues) and [open a new one](https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/issues/new) if needed.  If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
+If you're running into an issue, please take a look through [existing issues](https://github.com/linchpin/figma-wordpress-theme-json-sync/issues) and [open a new one](https://github.com/linchpin/figma-wordpress-theme-json-sync/issues/new) if needed.  If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
 
 ### Suggesting enhancements
 
-New features and enhancements are also managed via [issues](https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/issues).
+New features and enhancements are also managed via [issues](https://github.com/linchpin/figma-wordpress-theme-json-sync/issues).
 
 ### Pull requests
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <table width="100%">
 	<tr>
 		<td align="left" width="70%">
-			<strong>Figma to WordPress theme.json Exporter</strong><br />
-			A Figma plugin that converts design tokens and variables into WordPress theme.json format for seamless design-to-development workflows.
+			<strong>Figma WordPress theme.json Sync</strong><br />
+			A Figma plugin that syncs design tokens and variables between Figma and WordPress theme.json format for seamless design-to-development workflows.
 		</td>
 		<td align="center" width="30%">
-			<a href="https://github.com/linchpin/figma-to-wordpress-theme-json-exporter"><img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" alt="Maintained: yes" /></a>
-			<a href="https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/blob/develop/LICENSE.md"><img src="https://img.shields.io/github/license/linchpin/figma-to-wordpress-theme-json-exporter" alt="License" /></a>
-			<a href="https://github.com/linchpin/figma-to-wordpress-theme-json-exporter"><img src="https://img.shields.io/badge/support-beta-blueviolet.svg" alt="Support: Beta" /></a>
+			<a href="https://github.com/linchpin/figma-wordpress-theme-json-sync"><img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" alt="Maintained: yes" /></a>
+			<a href="https://github.com/linchpin/figma-wordpress-theme-json-sync/blob/develop/LICENSE.md"><img src="https://img.shields.io/github/license/linchpin/figma-wordpress-theme-json-sync" alt="License" /></a>
+			<a href="https://github.com/linchpin/figma-wordpress-theme-json-sync"><img src="https://img.shields.io/badge/support-beta-blueviolet.svg" alt="Support: Beta" /></a>
 		</td>
 	</tr>
 	<tr>
@@ -22,7 +22,7 @@
 
 ## What is this plugin?
 
-This Figma plugin converts Figma design tokens and variables into WordPress theme.json format, placing all variables under the `settings.custom` section according to WordPress standards. It streamlines the design-to-development workflow for WordPress block themes.
+This Figma plugin syncs design tokens and variables between Figma and WordPress theme.json format. It supports exporting Figma variables to theme.json, importing theme.json back into Figma, and creating variables from WordPress schema definitions. It streamlines the design-to-development workflow for WordPress block themes.
 
 > **Note:** This is a heavily modified fork of the original [10up Figma to theme.json plugin](https://github.com/10up/figma-to-wordpress-theme-json-exporter). Our version is opinionated toward Linchpin's approach to component export for design systems and client websites. If you need a more stable, general-purpose solution, consider the original 10up plugin.
 
@@ -389,8 +389,8 @@ For architecture details and contribution guidelines, see [DEVELOPER.md](wiki/DE
 
 **Beta:** This project is actively maintained but still evolving. Bug reports, feature requests, and pull requests are welcome. Please be cautious using this in production environments.
 
-- [Open an issue](https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/issues) for bugs or feature requests
-- [View the changelog](https://github.com/linchpin/figma-to-wordpress-theme-json-exporter/blob/develop/CHANGELOG.md) for release history
+- [Open an issue](https://github.com/linchpin/figma-wordpress-theme-json-sync/issues) for bugs or feature requests
+- [View the changelog](https://github.com/linchpin/figma-wordpress-theme-json-sync/blob/develop/CHANGELOG.md) for release history
 
 ## Contributing
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Figma to WordPress Theme.json",
+  "name": "Figma WordPress Theme.json Sync",
   "id": "1476325215239454172",
   "api": "1.0.0",
   "editorType": ["figma"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "figma-to-wordpress-theme-json-exporter",
+	"name": "figma-wordpress-theme-json-sync",
 	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "figma-to-wordpress-theme-json-exporter",
+			"name": "figma-wordpress-theme-json-sync",
 			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-	"name": "figma-to-wordpress-theme-json-exporter",
+	"name": "figma-wordpress-theme-json-sync",
 	"version": "1.3.0",
-	"description": "Generate WordPress theme.json from Figma variables",
-	"homepage": "https://github.com/linchpin/figma-to-wordpress-theme-json-exporter",
+	"description": "Sync design tokens between Figma variables and WordPress theme.json",
+	"homepage": "https://github.com/linchpin/figma-wordpress-theme-json-sync",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/linchpin/figma-to-wordpress-theme-json-exporter.git"
+		"url": "https://github.com/linchpin/figma-wordpress-theme-json-sync.git"
 	},
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
## Summary

- Rename package from `figma-to-wordpress-theme-json-exporter` to `figma-wordpress-theme-json-sync`
- Update display name from "Figma to WordPress Theme.json Exporter" to "Figma WordPress Theme.json Sync"
- Update package description to reflect sync capability: "Sync design tokens between Figma variables and WordPress theme.json"
- Update all documentation and GitHub URLs to use new slug

This better reflects the plugin's bidirectional capabilities: export, import, schema-based creation, and CSS variable syntax transformations.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>